### PR TITLE
Remove spaces between steam path and separating "|"symbols in default config

### DIFF
--- a/src/bin/eidolon.rs
+++ b/src/bin/eidolon.rs
@@ -122,7 +122,7 @@ fn init() {
         .open(get_home() + "/.config/eidolon/config")
         .unwrap();
     file.write_all(
-        (String::from("steam_dirs: | $HOME/.local/share/Steam/steamapps |\nmenu_command: | rofi -theme sidebar -mesg 'eidolon game:' -p '> ' -dmenu |\nprefix_command: | |")).as_bytes(),
+        (String::from("steam_dirs: |$HOME/.local/share/Steam/steamapps|\nmenu_command: | rofi -theme sidebar -mesg 'eidolon game:' -p '> ' -dmenu |\nprefix_command: | |")).as_bytes(),
         ).unwrap();
     println!("Correctly initialized base config. Please run again to use eidolon.");
 }


### PR DESCRIPTION
The regex path search does not support spaces between the "|"s. The default config on the readme does not have them, but the default generated by the application does. This patch simply removes them from the default config generated by the application on first run.

It took me a while to figure out why none of my games were being detected!